### PR TITLE
Fix mobile menu icon functionality

### DIFF
--- a/src/components/Global.scss
+++ b/src/components/Global.scss
@@ -1848,8 +1848,11 @@ body {
       height: 100vh;
       background: rgba(10, 10, 10, 0.95);
       backdrop-filter: blur(20px);
+      display: flex;
       flex-direction: column;
       justify-content: center;
+      align-items: center;
+      gap: var(--space-md);
       transition: right var(--transition-normal);
       z-index: 999;
       


### PR DESCRIPTION
Add missing flexbox properties to the mobile menu to ensure it displays correctly.

The mobile menu's `.links` class was missing `display: flex` and `align-items: center` within the mobile media query, preventing it from rendering properly even when the `open` class was applied.